### PR TITLE
test.bat path to VsDevCmd updated

### DIFF
--- a/test.bat
+++ b/test.bat
@@ -1,4 +1,4 @@
-call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools\VsDevCmd.bat"
+call "%VS120COMNTOOLS%\VsDevCmd.bat"
 cd Accounting
 msbuild
 vstest.console Accounting.Tests\bin\Debug\Accounting.Tests.dll Application.Web.Test\bin\Debug\Application.Web.Test.dll


### PR DESCRIPTION
Path to VS2013 VsDevCmd updated with environment variable instead of fixed path, since not all VS installations are in C default path.
Please check if this path works before accepting the change.
